### PR TITLE
Remove .env from version control

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-DATABASE_URL="postgres://localhost:5432/music_capstone_db"
-PGDATABSE="music_capstone_db"
-PGPORT="5432"
-PGUSER="postgres" 


### PR DESCRIPTION
### Remove `.env`

>Even if it’s ignored now, Git still tracks files already added.

---

### Remove 
``` bash
git rm --cached .env
```
``` bash 
git commit -m "Remove .env from version control"
```